### PR TITLE
feat: add size path parameter to image/thumbnail endpoints

### DIFF
--- a/openapi/lambdas.yaml
+++ b/openapi/lambdas.yaml
@@ -34,6 +34,10 @@ paths:
     $ref: 'paths/lambdas/lambdas@collections@contents@{urn}@thumbnail.yaml' 
   /collections/contents/{urn}/image:
     $ref: 'paths/lambdas/lambdas@collections@contents@{urn}@image.yaml' 
+  /collections/contents/{urn}/thumbail/{size}:
+    $ref: 'paths/lambdas/lambdas@collections@contents@{urn}@thumbnail@{size}.yaml' 
+  /collections/contents/{urn}/image/{size}:
+    $ref: 'paths/lambdas/lambdas@collections@contents@{urn}@image@{size}.yaml' 
   /collections/standard/erc721/{chainId}/{contract}/{option}/{emission}:
     $ref: 'paths/lambdas/lambdas@collections@standard@erc721@{chainId}@{contract}@{option}@{emission}.yaml'
   /collections/wearables:

--- a/openapi/paths/lambdas/lambdas@collections@contents@{urn}@image@{size}.yaml
+++ b/openapi/paths/lambdas/lambdas@collections@contents@{urn}@image@{size}.yaml
@@ -1,6 +1,6 @@
 get:
-  operationId: getImage
-  summary: Download URN image with default size
+  operationId: getSizedImage
+  summary: Download URN image
   tags:
     - Lambdas
   description: Downloads the image for the specified urn
@@ -9,26 +9,32 @@ get:
       name: urn
       required: true
       schema:
-        type: string        
+        type: string
         example: urn:decentraland:matic:collections-v2:0x04e43281f36e1f1bfae6f38bc276cb48fb8ac632:0
       description: Uniform Resource Name (URN) that identifies the asset
+    - in: path
+      name: size
+      required: true
+      schema:
+        type: string
+        enum: [128, 256, 512, 1024]
+      description: Image size to be return
   responses:
-    '200':
+    "200":
       description: Resource image
-      headers: 
+      headers:
         ETag:
           schema:
             type: string
-            example: QmVzr55TyXcrbQUWBN6rf7K7zkZsTFnBK19LvgYM9CxFbu-size
-          description: Double-quoted string with the hashId-size        
+            example: QmVzr55TyXcrbQUWBN6rf7K7zkZsTFnBK19LvgYM9CxFbu
+          description: Double-quoted string with the hashId
         Cache-Control:
           schema:
             type: string
-            example: 'public,max-age=31536000,immutable'
+            example: "public,max-age=31536000,immutable"
           description: Rules for caching in the request/response
       content:
         image/png:
           schema:
             type: string
             format: binary
-            example: binary

--- a/openapi/paths/lambdas/lambdas@collections@contents@{urn}@thumbnail.yaml
+++ b/openapi/paths/lambdas/lambdas@collections@contents@{urn}@thumbnail.yaml
@@ -19,15 +19,15 @@ get:
         ETag:
           schema:
             type: string
-            example: QmVzr55TyXcrbQUWBN6rf7K7zkZsTFnBK19LvgYM9CxFbu
-          description: Double-quoted string with the hashId        
+            example: QmVzr55TyXcrbQUWBN6rf7K7zkZsTFnBK19LvgYM9CxFbu-size
+          description: Double-quoted string with the hashId-size        
         Cache-Control:
           schema:
             type: string
             example: 'public,max-age=31536000,immutable'
           description: Rules for caching in the request/response
       content:
-        application/octet-stream:
+        image/png:
           schema:
             type: string
             format: binary

--- a/openapi/paths/lambdas/lambdas@collections@contents@{urn}@thumbnail.yaml
+++ b/openapi/paths/lambdas/lambdas@collections@contents@{urn}@thumbnail.yaml
@@ -1,6 +1,6 @@
 get:
   operationId: getThumbnail
-  summary: Download thumbnail image
+  summary: Download thumbnail image with default size
   tags:
     - Lambdas
   description: Downloads a thumbnail image for the specified urn

--- a/openapi/paths/lambdas/lambdas@collections@contents@{urn}@thumbnail@{size}.yaml
+++ b/openapi/paths/lambdas/lambdas@collections@contents@{urn}@thumbnail@{size}.yaml
@@ -1,9 +1,9 @@
 get:
-  operationId: getImage
-  summary: Download URN image with default size
+  operationId: getSizedThumbnail
+  summary: Download thumbnail image
   tags:
     - Lambdas
-  description: Downloads the image for the specified urn
+  description: Downloads a thumbnail image for the specified urn
   parameters:
     - in: path
       name: urn
@@ -12,14 +12,22 @@ get:
         type: string        
         example: urn:decentraland:matic:collections-v2:0x04e43281f36e1f1bfae6f38bc276cb48fb8ac632:0
       description: Uniform Resource Name (URN) that identifies the asset
+    - in: path
+      name: size
+      required: true
+      schema:
+        type: string
+        enum: [128, 256, 512, 1024]
+      description: Image size to be return
+
   responses:
     '200':
-      description: Resource image
+      description: Thumbnail image 
       headers: 
         ETag:
           schema:
             type: string
-            example: QmVzr55TyXcrbQUWBN6rf7K7zkZsTFnBK19LvgYM9CxFbu-size
+            example: QmVzr55TyXcrbQUWBN6rf7K7zkZsTFnBK19LvgYM9CxFbu-1024
           description: Double-quoted string with the hashId-size        
         Cache-Control:
           schema:


### PR DESCRIPTION
## Description

Adding `size` path parameter to image and thumbnail endpoints.
It is related to this [PR](https://github.com/decentraland/catalyst/pull/726/files), and should be merge altogether.