### PR TITLE
chore: prevent publishing when creating PRs

### DIFF
--- a/.github/workflows/api-website.yml
+++ b/.github/workflows/api-website.yml
@@ -2,8 +2,6 @@ name: CI
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main ]
   schedule:
   - cron: '30 0 * * *'
 


### PR DESCRIPTION
## Description

Prevent publishing the API docs web when creating a new PR. This was causing new deployments for changes that were not reviewed.

## Changes

- Only publish changes when pushing changes to `main`