### PR TITLE
Revert "docs: add `readyToUse` to health endpoint"

### DIFF
--- a/openapi/components/examples/lambdas/200-health.json
+++ b/openapi/components/examples/lambdas/200-health.json
@@ -2,7 +2,6 @@
     "value": {
         "lambda":"Healthy",
         "content":"Healthy",
-        "comms":"Healthy",
-        "readyToUse": true
+        "comms":"Healthy"
      }
 }

--- a/openapi/components/schemas/lambdas/200-health.yaml
+++ b/openapi/components/schemas/lambdas/200-health.yaml
@@ -6,5 +6,3 @@ properties:
     type: string
   comms:
     type: string
-  readyToUse:
-    type: boolean


### PR DESCRIPTION
Reverts decentraland/catalyst-api-specs#24

https://github.com/decentraland/catalyst/pull/932