### PR TITLE
docs: removing deprecated tag as endpoinst are still valid

### DIFF
--- a/openapi/paths/comms/comms@islands.yaml
+++ b/openapi/paths/comms/comms@islands.yaml
@@ -1,5 +1,4 @@
 get:
-  deprecated: true
   operationId: getIslands
   summary: List of islands
   tags:

--- a/openapi/paths/comms/comms@islands@{islandId}.yaml
+++ b/openapi/paths/comms/comms@islands@{islandId}.yaml
@@ -1,5 +1,4 @@
 get:
-  deprecated: true
   operationId: getIsland
   summary: Island Details
   tags:

--- a/openapi/paths/comms/comms@peers.yaml
+++ b/openapi/paths/comms/comms@peers.yaml
@@ -1,5 +1,4 @@
 get:
-  deprecated: true
   operationId: getPeers
   summary: List of peers
   tags:


### PR DESCRIPTION
These enpoints were re-implemented on the new comms architecture and are still valid