### PR TITLE
fix: Modify parcel permissions and operators

### DIFF
--- a/openapi/components/schemas/lambdas/parcel-operators.yaml
+++ b/openapi/components/schemas/lambdas/parcel-operators.yaml
@@ -1,8 +1,22 @@
 type: object
 required:
   - address
+  - operator
+  - updateOperator
+  - updateManagers
+  - approvedForAll
 properties:
   address:
     type: string
   operator:
-    type: string
+    type: ['null', string]
+  updateOperator:
+    type: ['null', string]
+  updateManagers:
+    type: array
+    items:
+      type: string
+  approvedForAll:
+    type: array
+    items:
+      type: string

--- a/openapi/components/schemas/lambdas/parcel-permissions.yaml
+++ b/openapi/components/schemas/lambdas/parcel-permissions.yaml
@@ -2,8 +2,17 @@ type: object
 required:
   - address
   - operator
+  - updateOperator
+  - updateManager
+  - approvedForAll
 properties:
   address:
     type: boolean
   operator:
+    type: boolean
+  updateOperator:
+    type: boolean
+  updateManager:
+    type: boolean
+  approvedForAll:
     type: boolean


### PR DESCRIPTION
This PR modifies the schemas for the returned JSON body of `parcel-operators` and `parcel-permissions`.